### PR TITLE
Update Scroller.vue

### DIFF
--- a/src/components/Scroller.vue
+++ b/src/components/Scroller.vue
@@ -62,6 +62,7 @@
 
   ._v-container > ._v-content {
     width: 100%;
+    position: relative;
 
     -webkit-transform-origin: left top;
     -webkit-transform: translateZ(0);
@@ -78,10 +79,13 @@
   ._v-container > ._v-content > .pull-to-refresh-layer {
     width: 100%;
     height: 60px;
-    margin-top: -60px;
+    /*margin-top: -60px;*/
     text-align: center;
     font-size: 16px;
     color: #AAA;
+    /*使用绝对定位*/
+    position: absolute;
+    top: -60px;
   }
 
   ._v-container > ._v-content > .loading-layer {


### PR DESCRIPTION
解决v-content的内容高度包含了下拉刷新层的高度问题 不然容易导致设置min-content-height属性的时候是包含了下拉刷新层的高度,同时也会导致上拉的时候高度多出一个下拉刷新层的高度